### PR TITLE
Switch to using the direct bike profile for nearly everything. #56

### DIFF
--- a/backend/src/costs.rs
+++ b/backend/src/costs.rs
@@ -1,63 +1,30 @@
 use std::time::Duration;
 
 use geo::{Euclidean, Length};
-use graph::{Road, RoadID, Timer};
+use graph::{Road, Timer};
 
-use crate::{Highway, InfraType, LevelOfService, MapModel};
+use crate::{LevelOfService, MapModel};
 
 impl MapModel {
-    /// After some kind of edit, recalculate edge costs. Overwrites the only router.
+    /// After some kind of edit, recalculate edge costs for bicycle_quiet.
     pub fn recalculate_router(&mut self, timer: &mut Timer) {
-        timer.step("recalculate edge costs");
+        timer.step("recalculate edge costs for bicycle_quiet");
 
         let mut costs = Vec::new();
         for (idx, road) in self.graph.roads.iter().enumerate() {
-            costs.push(edge_cost(
-                road,
-                self.get_infra_type(RoadID(idx)),
-                self.los[idx],
-            ));
+            costs.push(quiet_edge_cost(road, self.los[idx]));
         }
         for (road, cost) in self.graph.roads.iter_mut().zip(costs.into_iter()) {
             road.cost = vec![cost];
         }
 
         timer.step("recalculate CH");
-        let profile = self.graph.profile_names["bicycle"];
+        let profile = self.graph.profile_names["bicycle_quiet"];
         self.graph.routers[profile.0].update_costs(&self.graph.roads, profile);
     }
 }
 
-fn edge_cost(road: &Road, infra_type: InfraType, los: LevelOfService) -> Duration {
-    // Courtesy CycleStreets
-    let _quietness = match infra_type {
-        InfraType::SegregatedWide => 100,
-        InfraType::OffRoad => 100,
-        InfraType::SegregatedNarrow => 80,
-        InfraType::SharedFootway => 80,
-        InfraType::CycleLane => match Highway::classify(&road.osm_tags).unwrap() {
-            Highway::Primary => 40,
-            Highway::Secondary => 50,
-            Highway::Tertiary => 60,
-            // TODO Assume worst case. That's clearly wrong; need to revisit all of these cases.
-            _ => 40,
-        },
-        InfraType::MixedTraffic => match Highway::classify(&road.osm_tags).unwrap() {
-            // TODO Guessing for these
-            Highway::Motorway | Highway::Trunk => 10,
-            Highway::Primary => 20,
-            Highway::Secondary => 30,
-            Highway::Tertiary => 40,
-            Highway::Unclassified => 70,
-            // See special case: https://github.com/nptscot/npw/issues/29#issuecomment-2508180511
-            Highway::Residential | Highway::Service => 60,
-            // TODO LivingStreet should be quieter
-            Highway::LivingStreet => 70,
-            // TODO Check these assumptions. What does MixedTraffic even mean in this case?
-            Highway::Cycleway | Highway::Footway | Highway::Pedestrian | Highway::Path => 85,
-        },
-    };
-
+fn quiet_edge_cost(road: &Road, los: LevelOfService) -> Duration {
     // TODO Just making these up for now!
     let penalty = match los {
         LevelOfService::High => 1.0,

--- a/backend/src/existing.rs
+++ b/backend/src/existing.rs
@@ -71,6 +71,7 @@ impl Highway {
 }
 
 /// This determines what's in the graph. The cost function is just based on distance.
+// TODO Incorporate gradient
 pub fn bicycle_profile(tags: &Tags, linestring: &LineString) -> (Direction, Duration) {
     let exclude = (Direction::None, Duration::ZERO);
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -75,6 +75,8 @@ pub struct MapModel {
     tiers: Vec<Option<Tier>>,
     #[serde(skip_serializing, skip_deserializing, default)]
     los: Vec<LevelOfService>,
+    #[serde(skip_serializing, skip_deserializing, default)]
+    quiet_router_ok: bool,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -167,6 +169,7 @@ impl MapModel {
             override_infra_type,
             tiers,
             los,
+            quiet_router_ok: false,
         }
     }
 
@@ -192,6 +195,8 @@ impl MapModel {
         self.los = (0..self.graph.roads.len())
             .map(|idx| self.calculate_level_of_service(RoadID(idx)))
             .collect();
+
+        self.quiet_router_ok = false;
     }
 
     pub fn get_infra_type(&self, r: RoadID) -> InfraType {

--- a/backend/src/od.rs
+++ b/backend/src/od.rs
@@ -99,6 +99,7 @@ impl CountsOD {
 impl MapModel {
     pub fn od_counts(&self, fast_sample: bool) -> Result<CountsOD> {
         let keep_directness_routes = 10;
+        let profile = self.graph.profile_names["bicycle_direct"];
 
         let mut rng = WyRand::new_seed(42);
 
@@ -123,7 +124,6 @@ impl MapModel {
                 let pt1 = self.od_zones[zone1].random_point(&mut rng);
                 let pt2 = self.od_zones[zone2].random_point(&mut rng);
 
-                let profile = self.graph.profile_names["bicycle"];
                 let start = self.graph.snap_to_road(pt1, profile);
                 let end = self.graph.snap_to_road(pt2, profile);
                 let Ok(route) = self.graph.routers[profile.0].route(&self.graph, start, end) else {

--- a/backend/src/places.rs
+++ b/backend/src/places.rs
@@ -40,7 +40,7 @@ impl School {
             if boundary_wgs84.contains(&x.geometry) {
                 let point = graph.mercator.to_mercator(&x.geometry);
                 let road = graph
-                    .snap_to_road(point.into(), graph.profile_names["bicycle"])
+                    .snap_to_road(point.into(), graph.profile_names["bicycle_direct"])
                     .road;
                 schools.push(School {
                     point,
@@ -97,7 +97,7 @@ impl GPHospital {
                 if boundary_wgs84.contains(&x.geometry) {
                     let point = graph.mercator.to_mercator(&x.geometry);
                     let road = graph
-                        .snap_to_road(point.into(), graph.profile_names["bicycle"])
+                        .snap_to_road(point.into(), graph.profile_names["bicycle_direct"])
                         .road;
                     gp_hospitals.push(GPHospital {
                         point,
@@ -258,7 +258,7 @@ impl DataZone {
     }
 
     pub fn from_gj(gj: &str, boundary_wgs84: &MultiPolygon, graph: &Graph) -> Result<Vec<Self>> {
-        let profile = graph.profile_names["bicycle"];
+        let profile = graph.profile_names["bicycle_direct"];
 
         let mut zones = Vec::new();
         let mut densities = Vec::new();

--- a/backend/src/route_snapper.rs
+++ b/backend/src/route_snapper.rs
@@ -9,7 +9,7 @@ use crate::{Dir, MapModel};
 
 impl MapModel {
     pub fn to_route_snapper_graph(&self) -> RouteSnapperMap {
-        let profile = self.graph.profile_names["bicycle"];
+        let profile = self.graph.profile_names["bicycle_direct"];
 
         let mut nodes = Vec::new();
         for i in &self.graph.intersections {

--- a/backend/src/wasm.rs
+++ b/backend/src/wasm.rs
@@ -116,7 +116,13 @@ impl MapModel {
     }
 
     #[wasm_bindgen(js_name = evaluateRoute)]
-    pub fn evaluate_route_wasm(&self, input: JsValue) -> Result<String, JsValue> {
+    pub fn evaluate_route_wasm(&mut self, input: JsValue) -> Result<String, JsValue> {
+        if !self.quiet_router_ok {
+            let mut timer = Timer::new("recalculate bicycle_quiet", None);
+            self.recalculate_router(&mut timer);
+            self.quiet_router_ok = true;
+        }
+
         let req: EvaluateRouteRequest = serde_wasm_bindgen::from_value(input)?;
         self.evaluate_route(
             self.graph.mercator.pt_to_mercator(Coord {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -56,10 +56,10 @@ fn create(input_bytes: &[u8], boundary_gj: &str, timer: &mut Timer) -> Result<Ma
         Box::new(remove_disconnected_components),
         vec![
             (
-                "bicycle".to_string(),
+                "bicycle_quiet".to_string(),
                 Box::new(backend::existing::bicycle_profile),
             ),
-            // TODO This is wasteful in a few ways. bicycle will change with edits, but
+            // TODO This is wasteful in a few ways. bicycle_quiet will change with edits, but
             // bicycle_direct is immutable. At least clone the Router.
             (
                 "bicycle_direct".to_string(),
@@ -391,7 +391,7 @@ fn read_greenspaces(
     graph: &Graph,
 ) -> Result<Vec<backend::places::Greenspace>> {
     let mut access_points_per_site = read_access_points(access_pts_path, graph)?;
-    let profile = graph.profile_names["bicycle"];
+    let profile = graph.profile_names["bicycle_direct"];
 
     let dataset = Dataset::open(main_path)?;
     let mut layer = dataset.layer(0)?;

--- a/web/src/Directions.svelte
+++ b/web/src/Directions.svelte
@@ -2,8 +2,6 @@
   import type { RouteGJ, Step } from "./types";
 
   export let gj: RouteGJ;
-  export let showDirectBikeRoute: boolean;
-  export let showCarRoute: boolean;
 
   let byInfraType = (step: Step) => step.infra_type;
   let byLos = (step: Step) => step.los;
@@ -45,29 +43,6 @@
     return results.join(", ");
   }
 </script>
-
-<p>
-  Detour factor: <b>{(gj.route_length / gj.direct_length).toFixed(1)}x</b>
-  longer than straight line
-</p>
-
-<label>
-  <input type="checkbox" bind:checked={showCarRoute} />
-  <b>{(gj.route_length / gj.car_length).toFixed(1)}x</b>
-  longer than the driving route (in
-  <span style:color="red">red</span>
-  )
-</label>
-
-<label>
-  <input type="checkbox" bind:checked={showDirectBikeRoute} />
-  <b>{(gj.route_length / gj.direct_bike_length).toFixed(1)}x</b>
-  longer than the direct cycling route (in
-  <span style:color="blue">blue</span>
-  )
-</label>
-
-<hr />
 
 <p>{numChanges(gj, byInfraType)} changes in infrastructure type</p>
 <p>By length: {percentages(gj, byInfraType)}</p>

--- a/web/src/EvaluateRouteMode.svelte
+++ b/web/src/EvaluateRouteMode.svelte
@@ -28,7 +28,7 @@
   let gj: RouteGJ | null = null;
   let err = "";
   let breakdown: "" | "los" | "infra_type" | "gradient" = "los";
-  let showDirectBikeRoute = false;
+  let showQuietBikeRoute = false;
   let showCarRoute = false;
 
   async function update(
@@ -89,6 +89,11 @@
       <b>B</b>
       pins to find a route. (Hint: right-click to set the first pin somewhere.)
     </p>
+    <p>
+      Note the direct route is shown, ignoring bad infrastructure. This is to
+      emphasize whether or not that direct route has been adequately improved by
+      your network edits so far.
+    </p>
 
     {#if err}
       <p>{err}</p>
@@ -111,7 +116,25 @@
     {/if}
 
     {#if gj}
-      <Directions {gj} bind:showDirectBikeRoute bind:showCarRoute />
+      <label>
+        <input type="checkbox" bind:checked={showCarRoute} />
+        <b>{(gj.direct_bike_length / gj.car_length).toFixed(1)}x</b>
+        longer than the driving route (in
+        <span style:color="red">red</span>
+        )
+      </label>
+
+      <label>
+        <input type="checkbox" bind:checked={showQuietBikeRoute} />
+        <b>{(gj.direct_bike_length / gj.quiet_bike_length).toFixed(1)}x</b>
+        longer than the quiet cycling route (in
+        <span style:color="blue">blue</span>
+        )
+      </label>
+
+      <hr />
+
+      <Directions {gj} />
     {/if}
   </div>
 
@@ -131,7 +154,7 @@
       <GeoJSON data={gj} generateId>
         <LineLayer
           {...layerId("eval-route-breakdown")}
-          filter={["==", ["get", "kind"], "actual"]}
+          filter={["==", ["get", "kind"], "bicycle_direct"]}
           paint={{
             "line-width": 20,
             "line-color": {
@@ -172,10 +195,10 @@
         />
 
         <LineLayer
-          {...layerId("eval-direct-bike-route")}
-          filter={["==", ["get", "kind"], "direct_bike"]}
+          {...layerId("eval-quiet-bike-route")}
+          filter={["==", ["get", "kind"], "quiet_bike"]}
           layout={{
-            visibility: showDirectBikeRoute ? "visible" : "none",
+            visibility: showQuietBikeRoute ? "visible" : "none",
           }}
           paint={{
             "line-width": 10,

--- a/web/src/common/zorder.ts
+++ b/web/src/common/zorder.ts
@@ -113,7 +113,7 @@ const layerZorder = [
   // Eval route mode
   "eval-route-breakdown",
   "eval-car-route",
-  "eval-direct-bike-route",
+  "eval-quiet-bike-route",
 
   streets("Road labels"),
 

--- a/web/src/layers/PrecalculatedRouteNetwork.svelte
+++ b/web/src/layers/PrecalculatedRouteNetwork.svelte
@@ -63,10 +63,7 @@
   }[colorBy] as ExpressionSpecification;
 </script>
 
-<RoadLayerControls
-  name="NPT full network"
-  style="precalculated_rnet"
->
+<RoadLayerControls name="NPT full network" style="precalculated_rnet">
   <label>
     Trip purpose:
     <select bind:value={purpose}>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -25,10 +25,9 @@ export let infraTypeMapping: { [name: string]: [string, string] } =
   );
 
 export interface RouteGJ extends FeatureCollection {
-  direct_length: number;
   car_length: number;
+  quiet_bike_length: number;
   direct_bike_length: number;
-  route_length: number;
   directions: Step[];
 }
 


### PR DESCRIPTION
And clean up the old unused quietness code.

NPW has two types of bike routing:

1) direct just minimizes distance, ignoring the current level of service
2) quiet adds a penalty based on current level of service

Previously, we were using quiet for "Route network (calculated)", which calculates the full route network for the OD data, and for the "Percent of demand by level of service" breakdown. In last week's calls, we determined this is incorrect. The purpose of NPW is to edit the network to make the direct route good. So this PR switches both of those uses to use the direct routing.

This change is illustrated in three ways.

# Impact 1

First, that "percent of demand by LoS" breakdown. In EDB with a blank network:
- before (quiet routing): 73% high, 21 medium, 5 low
- after (direct routing): 27% high, 30 medium, 40 low

EDB with just the CN (primary and secondary only):
- before/quiet: 93 high, 6 medium, 1 low
- after/direct: 82 high, 13 medium, 4 low

This makes much more sense. If you start with a totally blank map, not even existing infra from OSM, you wouldn't expect 73% of demand to be on roads already high LoS. That was happening because there are lots of small streets with high LoS, but they cause extremely indirect routes, and also don't reflect the cost of crossing over severances to connect those wiggly routes.

# Impact 2

Evaluate route mode on a blank EDB shows the quiet route, with almost totally high LoS:
![image](https://github.com/user-attachments/assets/a406317f-0ae3-4762-8562-d4fca9e83e19)

Let's flip that, now that we calculate the direct route:
![image](https://github.com/user-attachments/assets/f7fd93c2-e040-4409-9d8b-056e80f549b0)
It's now obvious why the direct route sucks, except for a tiny bit of green in the centre.

# Impact 3

Before, the calculated network put high flows on green, small roads:
![image](https://github.com/user-attachments/assets/576b6c1e-545a-45bf-bfaa-0318b4bd451d)


Now, with the direct routing, the calculated network shows high flows on bad roads:
![image](https://github.com/user-attachments/assets/fc900c2b-aba9-43ec-8d0a-8c51cf57e67f)