### PR TITLE
When calculating reachability, don't cross perpendicular over a sever…

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -568,7 +568,7 @@ dependencies = [
 [[package]]
 name = "geojson"
 version = "0.24.1"
-source = "git+https://github.com/georust/geojson#5532d2d05dea0767d0e856a4ca9293bebff4f1b7"
+source = "git+https://github.com/georust/geojson#341f937790b7d75964f1a07198671257f9bf005a"
 dependencies = [
  "geo-types",
  "log",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "graph"
 version = "0.1.0"
-source = "git+https://github.com/a-b-street/15m#1b33bfd2a12ba06043ed32bd94d01b3d2a188b4c"
+source = "git+https://github.com/a-b-street/15m#5cf78c1dc12550471d1c4f16de377aeb38114af3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1370,7 +1370,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/a-b-street/utils#88666e7363f1693597e5ed6afe5a1ba498fd187c"
+source = "git+https://github.com/a-b-street/utils#10d8bf23282fb601ffc3eeb78b5ea8b9b1acd496"
 dependencies = [
  "anyhow",
  "fast_paths",


### PR DESCRIPTION
…ance

# Before

![image](https://github.com/user-attachments/assets/dd13cb1c-4662-4e69-bd71-884b749904bb)

Before this PR, from the snippet of green network, the purple is all reachable. Note this crosses over a red severance to the north, claiming some more low-traffic streets are reachable. This is incorrect, because that E/W road is a severance.

# After

![image](https://github.com/user-attachments/assets/247fa95d-017f-4e3e-8e32-bcbfed609d9e)
Now it stops at the severance as expected.

How can the user overcome this severance? A few ways. First, they could build **along** the severance. We assume that as part of linear infrastructure, appropriate crossings are installed.
![image](https://github.com/user-attachments/assets/9fe7c197-8ed4-4aa0-ab1b-bd90de377487)

FEEDBACK NEEDED: what if the crossing is right at the end of a treated severance? Right now, I'm considering this crossable:
![image](https://github.com/user-attachments/assets/d6fb8977-e144-465b-8e01-379d5bc64536)
@mvl22, @Robinlovelace 

The other way to cross the severance is to leave it alone, but explicitly build something that crosses it. We assume that would include a crossing.
![image](https://github.com/user-attachments/assets/afdd39af-3adc-4340-858e-1fd101c26d50)