### PR TITLE
Route overhaul 11th

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.29.1"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8798f09c0fb3625cf216569408e151a1884c3a028a0b533b7c223ae8f695c89a"
+checksum = "34f0e6e028c581e82e6822a68869514e94c25e7f8ea669a2d8595bdf7461ccc5"
 dependencies = [
  "earcutr",
  "float_next_after",
@@ -335,12 +335,13 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff16065e5720f376fbced200a5ae0f47ace85fd70b7e54269790281353b6d61"
+checksum = "3bd1157f0f936bf0cd68dec91e8f7c311afe60295574d62b70d4861a1bfdf2d9"
 dependencies = [
  "approx",
  "num-traits",
+ "rayon",
  "rstar",
  "serde",
 ]
@@ -356,8 +357,8 @@ dependencies = [
 
 [[package]]
 name = "geojson"
-version = "0.24.1"
-source = "git+https://github.com/georust/geojson#5532d2d05dea0767d0e856a4ca9293bebff4f1b7"
+version = "0.24.2"
+source = "git+https://github.com/georust/geojson#5380bfded95dd5c020ddd62b0769899b50fab42a"
 dependencies = [
  "geo-types",
  "log",
@@ -369,7 +370,7 @@ dependencies = [
 [[package]]
 name = "graph"
 version = "0.1.0"
-source = "git+https://github.com/a-b-street/15m#1b33bfd2a12ba06043ed32bd94d01b3d2a188b4c"
+source = "git+https://github.com/a-b-street/15m#e21e06ff30ae764e845308a17ff2307049e36867"
 dependencies = [
  "anyhow",
  "chrono",
@@ -430,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "i_float"
-version = "1.3.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fe043aae28ce70bd2f78b2f5f82a3654d63607c82594da4dabb8b6cb81f2b2"
+checksum = "775f9961a8d2f879725da8aff789bb20a3ddf297473e0c90af75e69313919490"
 dependencies = [
  "serde",
 ]
@@ -445,9 +446,9 @@ checksum = "347c253b4748a1a28baf94c9ce133b6b166f08573157e05afe718812bc599fcd"
 
 [[package]]
 name = "i_overlay"
-version = "1.7.2"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a469f68cb8a7cef375b2b0f581faf5859b4b50600438c00d46b71acc25ebbd0c"
+checksum = "01882ce5ed786bf6e8f5167f171a4026cd129ce17d9ff5cbf1e6749b98628ece"
 dependencies = [
  "i_float",
  "i_key_sort",
@@ -458,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "i_shape"
-version = "1.3.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b44852d57a991c7dedaf76c55bc44f677f547ff899a430d29e13efd6133d7d8"
+checksum = "27dbe9e5238d6b9c694c08415bf00fb370b089949bd818ab01f41f8927b8774c"
 dependencies = [
  "i_float",
  "serde",
@@ -944,7 +945,7 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/a-b-street/utils#88666e7363f1693597e5ed6afe5a1ba498fd187c"
+source = "git+https://github.com/a-b-street/utils#bee9d67a18f4e55d53ed004945995384d8d49bbe"
 dependencies = [
  "anyhow",
  "fast_paths",

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -92,10 +92,11 @@ pub struct MapModel {
 pub struct Route {
     /// The unedited GeoJSON feature returned from route-snapper
     feature: Feature,
+    // The direction is only plumbed along for rendering/splitting purposes
+    roads: Vec<(RoadID, Dir)>,
+
     name: String,
     notes: String,
-    // Derived from full_path. The direction is only plumbed along for rendering/splitting purposes
-    roads: Vec<(RoadID, Dir)>,
     infra_type: InfraType,
     override_infra_type: bool,
     tier: Tier,

--- a/backend/src/route_snapper.rs
+++ b/backend/src/route_snapper.rs
@@ -92,10 +92,22 @@ impl MapModel {
             pts.push(pair[0].point.into());
 
             if pair[0].snapped && pair[1].snapped {
-                let start = self.graph.snap_to_road(pair[0].point.into(), profile);
-                let end = self.graph.snap_to_road(pair[1].point.into(), profile);
+                let start = self
+                    .closest_intersection
+                    .nearest_neighbor(&pair[0].point.into())
+                    .unwrap()
+                    .data;
+                let end = self
+                    .closest_intersection
+                    .nearest_neighbor(&pair[1].point.into())
+                    .unwrap()
+                    .data;
 
-                if let Ok(route) = self.graph.routers[profile.0].route(&self.graph, start, end) {
+                if let Ok(route) = self.graph.routers[profile.0].route_between_intersections(
+                    &self.graph,
+                    start,
+                    end,
+                ) {
                     pts.extend(route.linestring(&self.graph).into_inner());
 
                     for step in route.steps {

--- a/backend/src/route_snapper.rs
+++ b/backend/src/route_snapper.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use geo::{Coord, Line, LineInterpolatePoint, LineString};
+use geo::{Coord, LineString};
 use geojson::Feature;
 use graph::{Graph, IntersectionID, PathStep, RoadID};
 use serde::{Deserialize, Serialize};
@@ -30,36 +30,9 @@ impl MapModel {
     }
 
     pub fn get_extra_nodes(&self, waypt1: Waypoint, waypt2: Waypoint) -> Result<String> {
-        // If both waypoints aren't snapped, just return one extra node in the middle
-        if !waypt1.snapped || !waypt2.snapped {
-            // If one waypoint is snapped, use its snapped position for finding the middle
-            let profile = self.graph.profile_names["bicycle_direct"];
-            let pt1 = if waypt1.snapped {
-                let i = self
-                    .graph
-                    .snap_to_road(waypt1.point.into(), profile)
-                    .intersection;
-                self.graph.intersections[i.0].point
-            } else {
-                waypt1.point.into()
-            };
-            let pt2 = if waypt2.snapped {
-                let i = self
-                    .graph
-                    .snap_to_road(waypt2.point.into(), profile)
-                    .intersection;
-                self.graph.intersections[i.0].point
-            } else {
-                waypt2.point.into()
-            };
-
-            // TODO Need to be more careful with CRS here. But the frontend disabled freehand for
-            // now
-            let line = Line::new(pt1, pt2);
-            if let Some(midpt) = line.line_interpolate_point(0.5) {
-                return Ok(serde_json::to_string(&vec![(midpt.x(), midpt.y(), false)])?);
-            }
-        }
+        // TODO If both waypoints aren't snapped, just return one extra node in the middle
+        assert!(waypt1.snapped);
+        assert!(waypt2.snapped);
 
         let (roads, _) = self.waypoints_to_path(&vec![waypt1, waypt2]);
         let intersections = roads_to_intersections(&self.graph, &roads);

--- a/backend/src/wasm.rs
+++ b/backend/src/wasm.rs
@@ -7,7 +7,7 @@ use graph::{IntersectionID, RoadID, Timer};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
-use crate::route_snapper::InputRouteWaypoint;
+use crate::route_snapper::Waypoint;
 use crate::{evaluate::Breakdown, Dir, InfraType, MapModel, Route, Tier};
 
 static START: Once = Once::new();
@@ -384,7 +384,7 @@ impl MapModel {
     /// For the route snapper, return a Feature with the full geometry and properties.
     #[wasm_bindgen(js_name = snapRoute)]
     pub fn snap_route_wasm(&self, raw_waypoints: JsValue) -> Result<String, JsValue> {
-        let mut waypoints: Vec<InputRouteWaypoint> = serde_wasm_bindgen::from_value(raw_waypoints)?;
+        let mut waypoints: Vec<Waypoint> = serde_wasm_bindgen::from_value(raw_waypoints)?;
         for w in &mut waypoints {
             self.to_mercator(&mut w.point);
         }
@@ -399,8 +399,8 @@ impl MapModel {
         raw_waypt1: JsValue,
         raw_waypt2: JsValue,
     ) -> Result<String, JsValue> {
-        let mut waypt1: InputRouteWaypoint = serde_wasm_bindgen::from_value(raw_waypt1)?;
-        let mut waypt2: InputRouteWaypoint = serde_wasm_bindgen::from_value(raw_waypt2)?;
+        let mut waypt1: Waypoint = serde_wasm_bindgen::from_value(raw_waypt1)?;
+        let mut waypt2: Waypoint = serde_wasm_bindgen::from_value(raw_waypt2)?;
         self.to_mercator(&mut waypt1.point);
         self.to_mercator(&mut waypt2.point);
         self.get_extra_nodes(waypt1, waypt2).map_err(err_to_js)

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.29.1"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8798f09c0fb3625cf216569408e151a1884c3a028a0b533b7c223ae8f695c89a"
+checksum = "34f0e6e028c581e82e6822a68869514e94c25e7f8ea669a2d8595bdf7461ccc5"
 dependencies = [
  "earcutr",
  "float_next_after",
@@ -542,12 +542,13 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff16065e5720f376fbced200a5ae0f47ace85fd70b7e54269790281353b6d61"
+checksum = "3bd1157f0f936bf0cd68dec91e8f7c311afe60295574d62b70d4861a1bfdf2d9"
 dependencies = [
  "approx",
  "num-traits",
+ "rayon",
  "rstar 0.11.0",
  "rstar 0.12.0",
  "serde",
@@ -564,8 +565,8 @@ dependencies = [
 
 [[package]]
 name = "geojson"
-version = "0.24.1"
-source = "git+https://github.com/georust/geojson#341f937790b7d75964f1a07198671257f9bf005a"
+version = "0.24.2"
+source = "git+https://github.com/georust/geojson#5380bfded95dd5c020ddd62b0769899b50fab42a"
 dependencies = [
  "geo-types",
  "log",
@@ -585,7 +586,7 @@ dependencies = [
 [[package]]
 name = "graph"
 version = "0.1.0"
-source = "git+https://github.com/a-b-street/15m#5cf78c1dc12550471d1c4f16de377aeb38114af3"
+source = "git+https://github.com/a-b-street/15m#e21e06ff30ae764e845308a17ff2307049e36867"
 dependencies = [
  "anyhow",
  "chrono",
@@ -680,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "i_float"
-version = "1.3.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fe043aae28ce70bd2f78b2f5f82a3654d63607c82594da4dabb8b6cb81f2b2"
+checksum = "775f9961a8d2f879725da8aff789bb20a3ddf297473e0c90af75e69313919490"
 dependencies = [
  "serde",
 ]
@@ -695,9 +696,9 @@ checksum = "347c253b4748a1a28baf94c9ce133b6b166f08573157e05afe718812bc599fcd"
 
 [[package]]
 name = "i_overlay"
-version = "1.7.2"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a469f68cb8a7cef375b2b0f581faf5859b4b50600438c00d46b71acc25ebbd0c"
+checksum = "01882ce5ed786bf6e8f5167f171a4026cd129ce17d9ff5cbf1e6749b98628ece"
 dependencies = [
  "i_float",
  "i_key_sort",
@@ -708,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "i_shape"
-version = "1.3.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b44852d57a991c7dedaf76c55bc44f677f547ff899a430d29e13efd6133d7d8"
+checksum = "27dbe9e5238d6b9c694c08415bf00fb370b089949bd818ab01f41f8927b8774c"
 dependencies = [
  "i_float",
  "serde",
@@ -1358,7 +1359,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/a-b-street/utils#10d8bf23282fb601ffc3eeb78b5ea8b9b1acd496"
+source = "git+https://github.com/a-b-street/utils#bee9d67a18f4e55d53ed004945995384d8d49bbe"
 dependencies = [
  "anyhow",
  "fast_paths",

--- a/web/src/edit/EditRouteMode.svelte
+++ b/web/src/edit/EditRouteMode.svelte
@@ -59,30 +59,6 @@
       tier = feature.properties.tier;
 
       $waypoints = feature.properties.waypoints;
-
-      // TODO Debugging cases where auto-imported routes act oddly
-      if (false) {
-        let waypts1 = JSON.parse(JSON.stringify(feature.properties.waypoints));
-        let full_path1 = JSON.parse(
-          JSON.stringify(feature.properties.full_path),
-        );
-        let output = await $backend!.snapRoute($waypoints);
-        let waypts2 = JSON.parse(JSON.stringify(output.properties.waypoints));
-        let full_path2 = JSON.parse(
-          JSON.stringify(output.properties.full_path),
-        );
-
-        if (JSON.stringify(waypts1) != JSON.stringify(waypts2)) {
-          console.log(`waypts changed`);
-          console.log(waypts1);
-          console.log(waypts2);
-        }
-        if (JSON.stringify(full_path1) != JSON.stringify(full_path2)) {
-          console.log(`full_path changed`);
-          console.log(full_path1);
-          console.log(full_path2);
-        }
-      }
     }
   });
 
@@ -105,9 +81,10 @@
 
       await $backend!.setRoute(id, {
         feature,
+        roads: feature.properties.roads,
+
         name,
         notes,
-        full_path: feature.properties.full_path,
         infra_type: infraType,
         override_infra_type: overrideInfraType,
         tier,
@@ -150,7 +127,7 @@
       let feature = await $backend!.snapRoute(waypts);
       sectionsGj = await $backend!.autosplitRoute(
         id,
-        feature.properties.full_path,
+        feature.properties.roads,
         overrideInfraType ? infraType : null,
       );
     } catch (err) {}

--- a/web/src/edit/EditRouteMode.svelte
+++ b/web/src/edit/EditRouteMode.svelte
@@ -58,13 +58,7 @@
       overrideInfraType = feature.properties.override_infra_type;
       tier = feature.properties.tier;
 
-      // Transform into the correct format
-      $waypoints = feature.properties.waypoints.map((waypt) => {
-        return {
-          point: [waypt.lon, waypt.lat],
-          snapped: waypt.snapped,
-        };
-      });
+      $waypoints = feature.properties.waypoints;
 
       // TODO Debugging cases where auto-imported routes act oddly
       if (false) {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -159,6 +159,11 @@ export type RouteNode = { snapped: number } | { free: [number, number] };
 
 // TODO Reconcile these two
 
+export interface Waypoint {
+  point: [number, number];
+  snapped: boolean;
+}
+
 export interface SetRouteInput {
   feature: Feature<LineString, RouteProps>;
   name: string;
@@ -174,7 +179,7 @@ export interface RouteProps {
   name: string;
   notes: string;
   full_path: RouteNode[];
-  waypoints: any[];
+  waypoints: Waypoint[];
   infra_type: string;
   override_infra_type: boolean;
   tier: Tier;
@@ -233,11 +238,4 @@ export interface DynamicRoad {
   current_infra: string | null;
   current_tier: Tier | null;
   current_infra_fits: boolean;
-}
-
-// Route snapper
-
-export interface Waypoint {
-  point: [number, number];
-  snapped: boolean;
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -155,31 +155,31 @@ export type PrecalculatedDemand = FeatureCollection<
   total_quintile_sums: number[];
 };
 
-export type RouteNode = { snapped: number } | { free: [number, number] };
-
-// TODO Reconcile these two
-
 export interface Waypoint {
   point: [number, number];
   snapped: boolean;
 }
 
+// TODO Reconcile these two
+
 export interface SetRouteInput {
   feature: Feature<LineString, RouteProps>;
+  roads: [number, "Forwards" | "Backwards"][];
+
   name: string;
   notes: string;
-  full_path: RouteNode[];
   infra_type: string;
   override_infra_type: boolean;
   tier: Tier;
 }
 
 export interface RouteProps {
+  waypoints: Waypoint[];
   id: number;
+  roads: [number, "Forwards" | "Backwards"][];
+
   name: string;
   notes: string;
-  full_path: RouteNode[];
-  waypoints: Waypoint[];
   infra_type: string;
   override_infra_type: boolean;
   tier: Tier;

--- a/web/src/worker.ts
+++ b/web/src/worker.ts
@@ -18,7 +18,6 @@ import type {
   ODStats,
   POIs,
   RouteGJ,
-  RouteNode,
   RouteProps,
   SetRouteInput,
   Settlements,
@@ -108,14 +107,14 @@ export class Backend {
 
   autosplitRoute(
     editingRouteId: number | null,
-    full_path: RouteNode[],
+    roads: [number, "Forwards" | "Backwards"][],
     overrideInfraType: string | null,
   ): AutosplitRoute {
     this.checkReady();
     return JSON.parse(
       this.inner!.autosplitRoute(
         editingRouteId == null ? undefined : editingRouteId,
-        full_path,
+        roads,
         overrideInfraType,
       ),
     );
@@ -235,7 +234,7 @@ export class Backend {
     this.checkReady();
     let route = JSON.parse(this.inner!.fixUnreachablePOI(kind, idx));
     // TODO Hack around this necessary duplication
-    route.full_path = route.feature.properties.full_path;
+    route.roads = route.feature.properties.roads;
     return route;
   }
 


### PR DESCRIPTION
A few weeks ago, for #64, I switched from a separate route-snapper WASM backend to serving the routing queries using the main code used for the rest of the app. I made a critical error though -- by snapping waypoints to the nearest **road**, not **intersection**, this caused funny bugs like #65. Snapping a point exactly on the end of several road linestrings will pick an arbitrary road, so there was inconsistency between `snapRoute` and `autosplitRoute`, which both repeat a routing calculation.

Relatedly, the entire chain of code for setting / editing routes is a mess, because it's evolved organically, and the autosplitting stuff took a while to figure out.

This is a first step to clean things up. Breaking binary format change (need to regen all areas) and also breaks savefiles. More breakages for both will be coming.