### PR TITLE
Apply more SG styles

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.0.0",
       "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.7.2",
         "@scottish-government/design-system": "^3.0.0-beta.0",
         "@turf/boolean-intersects": "^7.2.0",
         "comlink": "^4.4.2",
@@ -500,6 +501,14 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@ianvs/prettier-plugin-sort-imports": {

--- a/web/package.json
+++ b/web/package.json
@@ -28,6 +28,7 @@
     "vite-plugin-wasm-pack": "0.1.11"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.7.2",
     "@scottish-government/design-system": "^3.0.0-beta.0",
     "@turf/boolean-intersects": "^7.2.0",
     "comlink": "^4.4.2",

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import "./style.css";
+  import "@scottish-government/design-system/dist/css/design-system.css";
+  import "@scottish-government/design-system/dist/scripts/design-system.js";
   import * as Comlink from "comlink";
   import type { Map, StyleSpecification } from "maplibre-gl";
   import { onMount } from "svelte";
@@ -61,6 +63,9 @@
   }
 
   onMount(async () => {
+    // @ts-expect-error This really exists for the SG design system, but TS doesn't know about it
+    window.DS.initAll();
+
     let params = new URLSearchParams(window.location.search);
     $boundaryName = params.get("boundary") || "LAD_City of Edinburgh";
     loading = `Loading ${$boundaryName}`;

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -2,6 +2,7 @@
   import "./style.css";
   import "@scottish-government/design-system/dist/css/design-system.css";
   import "@scottish-government/design-system/dist/scripts/design-system.js";
+  import "@fortawesome/fontawesome-free/css/all.min.css";
   import * as Comlink from "comlink";
   import type { Map, StyleSpecification } from "maplibre-gl";
   import { onMount } from "svelte";

--- a/web/src/MainMode.svelte
+++ b/web/src/MainMode.svelte
@@ -28,91 +28,106 @@
 
 <SplitComponent>
   <div slot="controls">
-    <div style="display: flex; justify-content: space-between;">
-      <h2>{titles[$currentStage]}</h2>
-
-      <HelpButton>
-        {#if $currentStage == "Primary"}
-          <p>
-            The primary route should be direct, coherent, meet high demand, and
-            potentially connect settlements. Key primary routes will form Active
-            Freeways. To draw the primary route, connect the high cycling demand
-            routes on the base map.
-          </p>
-        {:else if $currentStage == "Secondary"}
-          <p>
-            To draw the secondary route, please connect town centres and cover
-            medium cycling demand routes on the base map.
-          </p>
-        {:else if $currentStage == "LocalAccess"}
-          <p>
-            To draw the local access route, connect schools, GPs, hospitals,
-            green spaces, and neighbourhoods (especially deprived and densely
-            populated ones).
-          </p>
-        {:else if $currentStage == "LongDistance"}
-          <ul>
-            <li>
-              Long distance routes connect EDJ reachable settlements out with
-              main urban areas.
-            </li>
-            <li>
-              Settlements should be connected by high demand routes forming a
-              direct connection in most cases.
-            </li>
-            <li>
-              Long distance routes should connect directly to primary routes
-              within each settlement.
-            </li>
-            <li>Consider SIMD/transport poverty</li>
-            <li>
-              In limited circumstances, settlement can be connected by less
-              direct/more scenic routes (NCN)
-            </li>
-          </ul>
-        {:else if $currentStage == "assessment"}
-          <p>
-            Having designed your network, you can now assess its performance and
-            fix any problems.
-          </p>
-        {/if}
-
-        <label>
-          <input type="checkbox" bind:checked={$devMode} />
-          Dev mode
-        </label>
-      </HelpButton>
-    </div>
-
-    <div>
-      <button
-        class="primary"
-        on:click={() => ($mode = { kind: "edit-route", id: null })}
+    <div class="main-controls">
+      <header
+        class="ds_page-header"
+        style="display: flex; justify-content: space-between;"
       >
-        Draw new <kbd>r</kbd>
-        oute line
-      </button>
-    </div>
-    <div>
-      <button on:click={() => ($mode = { kind: "bulk-edit" })}>
-        Bulk edit
-      </button>
-    </div>
-    <div>
-      <button
-        on:click={() =>
-          ($mode = {
-            kind: "evaluate-journey",
-            prevMode: { kind: "main" },
-            browse: [],
-          })}
-      >
-        Evaluate a journey
-      </button>
-    </div>
+        <h2 class="ds_page-header__title">{titles[$currentStage]}</h2>
 
-    <AllControls />
+        <HelpButton>
+          {#if $currentStage == "Primary"}
+            <p>
+              The primary route should be direct, coherent, meet high demand,
+              and potentially connect settlements. Key primary routes will form
+              Active Freeways. To draw the primary route, connect the high
+              cycling demand routes on the base map.
+            </p>
+          {:else if $currentStage == "Secondary"}
+            <p>
+              To draw the secondary route, please connect town centres and cover
+              medium cycling demand routes on the base map.
+            </p>
+          {:else if $currentStage == "LocalAccess"}
+            <p>
+              To draw the local access route, connect schools, GPs, hospitals,
+              green spaces, and neighbourhoods (especially deprived and densely
+              populated ones).
+            </p>
+          {:else if $currentStage == "LongDistance"}
+            <ul>
+              <li>
+                Long distance routes connect EDJ reachable settlements out with
+                main urban areas.
+              </li>
+              <li>
+                Settlements should be connected by high demand routes forming a
+                direct connection in most cases.
+              </li>
+              <li>
+                Long distance routes should connect directly to primary routes
+                within each settlement.
+              </li>
+              <li>Consider SIMD/transport poverty</li>
+              <li>
+                In limited circumstances, settlement can be connected by less
+                direct/more scenic routes (NCN)
+              </li>
+            </ul>
+          {:else if $currentStage == "assessment"}
+            <p>
+              Having designed your network, you can now assess its performance
+              and fix any problems.
+            </p>
+          {/if}
+
+          <label>
+            <input type="checkbox" bind:checked={$devMode} />
+            Dev mode
+          </label>
+        </HelpButton>
+      </header>
+
+      <div>
+        <button
+          class="ds_button"
+          on:click={() => ($mode = { kind: "edit-route", id: null })}
+        >
+          Draw new route line
+        </button>
+      </div>
+      <div>
+        <button
+          class="ds_button ds_button--secondary"
+          on:click={() => ($mode = { kind: "bulk-edit" })}
+        >
+          Bulk edit
+        </button>
+      </div>
+      <div>
+        <button
+          class="ds_button ds_button--secondary"
+          on:click={() =>
+            ($mode = {
+              kind: "evaluate-journey",
+              prevMode: { kind: "main" },
+              browse: [],
+            })}
+        >
+          Evaluate a journey
+        </button>
+      </div>
+
+      <AllControls />
+    </div>
 
     <LeftSidebarStats />
   </div>
 </SplitComponent>
+
+<style>
+  .main-controls {
+    overflow-y: auto;
+    padding: 20px;
+  }
+</style>

--- a/web/src/TopBar.svelte
+++ b/web/src/TopBar.svelte
@@ -80,9 +80,9 @@
         {/each}
       </ul>
     </nav>
-
-    <!--<TopBarStats /> -->
   </div>
+
+  <TopBarStats />
 </header>
 
 <style>

--- a/web/src/TopBar.svelte
+++ b/web/src/TopBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+  import logo from "../assets/npt_logo.png?url";
   import { tierLabels } from "./colors";
-  import { Link } from "./common";
   import ManageFiles from "./common/ManageFiles.svelte";
   import { disableLayersPerStage, enableLayersPerStage } from "./layers/stores";
   import TopBarStats from "./stats/TopBarStats.svelte";
@@ -37,52 +37,84 @@
   let stages = { ...tierLabels, assessment: "Assess" };
 </script>
 
-<div>
-  <nav aria-label="breadcrumb">
-    <ul>
-      <li>NPW</li>
-      <li><a href="index.html">Select area</a></li>
-
-      <li><ManageFiles /></li>
-
-      {#each Object.entries(stages) as [stage, label]}
-        <li>
-          {#if $currentStage == stage}
-            <b>{label}</b>
-          {:else}
-            <Link on:click={() => changeStage(stage)}>{label}</Link>
-          {/if}
+<header>
+  <div class="site-navigation">
+    <nav class="ds_site-navigation">
+      <ul class="ds_site-navigation__list">
+        <li class="ds_site-navigation__item">
+          <a
+            class="ds_site-navigation__link"
+            href="https://www.npt.scot/"
+            target="_blank"
+          >
+            <img id="logo" src={logo} alt="NPT logo" />
+            NPW &nbsp;&gt;
+          </a>
         </li>
-      {/each}
-    </ul>
-  </nav>
 
-  <TopBarStats />
-</div>
+        <li class="ds_site-navigation__item">
+          <a class="ds_site-navigation__link" href="index.html">
+            Select area &nbsp;&gt;
+          </a>
+        </li>
+
+        <li class="ds_site-navigation__item">
+          <ManageFiles />
+        </li>
+
+        {#each Object.entries(stages) as [stage, label]}
+          <li class="ds_site-navigation__item">
+            <!-- svelte-ignore a11y-invalid-attribute -->
+            <a
+              class="ds_site-navigation__link {stage}"
+              class:ds_current={$currentStage == stage}
+              href="#"
+              on:click|preventDefault={() => changeStage(stage)}
+            >
+              {label}
+              {#if stage != "assessment"}
+                &nbsp;&gt;
+              {/if}
+            </a>
+          </li>
+        {/each}
+      </ul>
+    </nav>
+
+    <!--<TopBarStats /> -->
+  </div>
+</header>
 
 <style>
-  div {
+  header {
     display: flex;
-    justify-content: space-between;
-    padding: 4px;
+    padding: 0 20px;
+    box-shadow: 0px 10px 10px 0px #eee;
+  }
+  header #logo {
+    height: 30px;
+    margin-right: 10px;
+    vertical-align: middle;
   }
 
-  nav {
-    padding: 0 0.5rem;
+  .ds_site-navigation .ds_site-navigation__link {
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+  .ds_site-navigation .ds_current {
+    font-weight: bold;
   }
 
-  nav ul {
-    display: flex;
-    flex-wrap: wrap;
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    align-items: end;
+  .ds_site-navigation .ds_site-navigation__link.Primary:not(:focus):after {
+    border-bottom-color: var(--primary-tier-colour);
   }
-
-  nav li:not(:last-child)::after {
-    display: inline-block;
-    margin: 0 0.25rem;
-    content: ">";
+  .ds_site-navigation .ds_site-navigation__link.Secondary:not(:focus):after {
+    border-bottom-color: var(--secondary-tier-colour);
+  }
+  .ds_site-navigation .ds_site-navigation__link.LocalAccess:not(:focus):after {
+    border-bottom-color: var(--localaccess-tier-colour);
+  }
+  .ds_site-navigation .ds_site-navigation__link.LongDistance:not(:focus):after {
+    border-bottom-color: var(--longdistance-tier-colour);
   }
 </style>

--- a/web/src/common/HelpButton.svelte
+++ b/web/src/common/HelpButton.svelte
@@ -7,11 +7,19 @@
   let show = false;
 </script>
 
-<button on:click={() => (show = true)}>
-  <img src={icon} title="Help" alt="Help" />
-</button>
+<!-- svelte-ignore a11y-invalid-attribute -->
+<a href="#" on:click|preventDefault={() => (show = true)}>
+  <img src={icon} alt="Help" />
+</a>
 
 <Modal bind:show>
   <h2>Help</h2>
   <slot />
 </Modal>
+
+<style>
+  img {
+    float: right;
+    height: 16px;
+  }
+</style>

--- a/web/src/common/LegendWithToggles.svelte
+++ b/web/src/common/LegendWithToggles.svelte
@@ -6,20 +6,16 @@
   export let show: Writable<{ [name: string]: boolean }>;
 </script>
 
-<div style="display: flex">
+<ul>
   {#each Object.entries(colors) as [key, color]}
-    <span style:background={color} style:color="white">
+    <li style:background-color={color}>
       <label>
         <input type="checkbox" bind:checked={$show[key]} />
         {labels[key]}
       </label>
-    </span>
+    </li>
   {/each}
-</div>
+</ul>
 
 <style>
-  span {
-    width: 100%;
-    border: 1px solid black;
-  }
 </style>

--- a/web/src/common/ManageFiles.svelte
+++ b/web/src/common/ManageFiles.svelte
@@ -148,9 +148,14 @@
   }
 </script>
 
-<Link on:click={() => (open = true)}>
-  Select project: {$currentFilename}
-</Link>
+<!-- svelte-ignore a11y-invalid-attribute -->
+<a
+  class="ds_site-navigation__link"
+  href="#"
+  on:click|preventDefault={() => (open = true)}
+>
+  Select project: {$currentFilename}&nbsp;&gt;
+</a>
 
 <Modal bind:show={open}>
   <h2>Manage files</h2>

--- a/web/src/common/layout/Layout.svelte
+++ b/web/src/common/layout/Layout.svelte
@@ -34,6 +34,8 @@
     display: flex;
     flex-direction: column;
     justify-content: space between;
+    /* TODO hack, only want some parts to scroll */
+    overflow: auto;
   }
 
   .map {

--- a/web/src/common/layout/Layout.svelte
+++ b/web/src/common/layout/Layout.svelte
@@ -13,16 +13,11 @@
 </div>
 
 <style>
-  /* Legacy note: calling this "container" will clash with a pico built-in */
   .flex-container {
     display: flex;
     flex-direction: column;
     height: 100vh;
     margin: 0;
-  }
-
-  .top {
-    padding: 4px;
   }
 
   .content {
@@ -32,9 +27,13 @@
   }
 
   .controls {
-    width: 25%;
-    overflow-y: auto;
-    padding: 10px;
+    width: 25%; /* padding: 10px; */
+    min-width: 350px;
+
+    /* TODO no effect? */
+    display: flex;
+    flex-direction: column;
+    justify-content: space between;
   }
 
   .map {

--- a/web/src/edit/EditRouteMode.svelte
+++ b/web/src/edit/EditRouteMode.svelte
@@ -195,13 +195,12 @@
   {deleteRoute}
   editingExisting={id != null}
 >
-  <div slot="extra-controls">
-    <div>
-      <label>
-        Name:
-        <input type="text" bind:value={name} />
-      </label>
-    </div>
+  <div slot="extra-controls" class="main-controls">
+    <input
+      class="ds_input ds_input--fixed-20"
+      placeholder="Name"
+      bind:value={name}
+    />
 
     {#if $waypoints.length >= 2}
       {#if overrideInfraType}
@@ -209,7 +208,10 @@
           You've forced this route to always use {infraType}, assuming high
           Level of Service.
         </p>
-        <button on:click={() => (overrideInfraType = false)}>
+        <button
+          class="ds_button ds_button--secondary"
+          on:click={() => (overrideInfraType = false)}
+        >
           Remove override
         </button>
       {:else}
@@ -219,6 +221,7 @@
           Service.
         </p>
         <button
+          class="ds_button ds_button--secondary"
           on:click={() => {
             overrideInfraType = true;
             showOverrideModal = true;
@@ -260,12 +263,12 @@
       <SectionDiagram {breakdown} {sectionsGj} />
     {/if}
 
-    <div>
-      <label>
-        Notes:
-        <textarea rows="5" bind:value={notes} />
-      </label>
-    </div>
+    <textarea
+      class="ds_input"
+      rows="2"
+      placeholder="Notes"
+      bind:value={notes}
+    />
 
     <div>
       <label>
@@ -279,7 +282,11 @@
       </label>
     </div>
 
-    <button on:click={evalRoute} disabled={$waypoints.length < 2}>
+    <button
+      class="ds_button ds_button--secondary"
+      on:click={evalRoute}
+      disabled={$waypoints.length < 2}
+    >
       Evaluate this route
     </button>
 
@@ -306,3 +313,11 @@
   <PickInfraType bind:current={infraType} />
   <button on:click={() => (showOverrideModal = false)}>OK</button>
 </Modal>
+
+<style>
+  /** TODO These get nested in a strange way**/
+  .main-controls {
+    overflow-y: auto;
+    padding: 20px;
+  }
+</style>

--- a/web/src/layers/AllControls.svelte
+++ b/web/src/layers/AllControls.svelte
@@ -43,26 +43,26 @@
 </script>
 
 {#if $currentStage == "Primary"}
-  <h4>Relevant layers</h4>
+  <h3>Relevant layers</h3>
   <div bind:this={primary} />
 {/if}
 
 {#if $currentStage == "Secondary"}
-  <h4>Relevant layers</h4>
+  <h3>Relevant layers</h3>
   <div bind:this={secondary} />
 {/if}
 
 {#if $currentStage == "LocalAccess"}
-  <h4>Relevant layers</h4>
+  <h3>Relevant layers</h3>
   <div bind:this={localAccess} />
 {/if}
 
 {#if $currentStage == "LongDistance"}
-  <h4>Relevant layers</h4>
+  <h3>Relevant layers</h3>
   <div bind:this={longDistance} />
 {/if}
 
 {#if $currentStage == "assessment"}
-  <h4>Relevant layers</h4>
+  <h3>Relevant layers</h3>
   <div bind:this={networkAssessment} />
 {/if}

--- a/web/src/layers/roads/BottomPanel.svelte
+++ b/web/src/layers/roads/BottomPanel.svelte
@@ -11,31 +11,29 @@
   import { showNetworkInfraTypes, showNetworkTiers } from "../stores";
 </script>
 
-<div class="bottom-center">
-  <b>Show your new network as</b>
-  <div style:display="flex">
-    <button
-      style:font-size="12px"
-      style:background={$editsRoadStyle == "edits_tier" ? "green" : "grey"}
-      on:click={() => ($editsRoadStyle = "edits_tier")}
+<div class="network-style">
+  <p>Show network as:</p>
+
+  <ul>
+    <li class="tier" class:selected={$editsRoadStyle == "edits_tier"}>
+      <button on:click={() => ($editsRoadStyle = "edits_tier")}>
+        ‖‖&nbsp; Tier
+      </button>
+    </li>
+    <li
+      class="infrastructure"
+      class:selected={$editsRoadStyle == "edits_infra"}
     >
-      Tier
-    </button>
-    <button
-      style:font-size="12px"
-      style:background={$editsRoadStyle == "edits_infra" ? "green" : "grey"}
-      on:click={() => ($editsRoadStyle = "edits_infra")}
-    >
-      Infrastructure type
-    </button>
-    <button
-      style:font-size="12px"
-      style:background={$editsRoadStyle == "off" ? "green" : "grey"}
-      on:click={() => ($editsRoadStyle = "off")}
-    >
-      Hidden
-    </button>
-  </div>
+      <button on:click={() => ($editsRoadStyle = "edits_infra")}>
+        ‖‖&nbsp; Infrastructure type
+      </button>
+    </li>
+    <li class="hidden" class:selected={$editsRoadStyle == "off"}>
+      <button on:click={() => ($editsRoadStyle = "off")}>
+        &#10680;&nbsp; Hidden
+      </button>
+    </li>
+  </ul>
 
   {#if $editsRoadStyle == "edits_infra"}
     <LegendWithToggles
@@ -58,14 +56,53 @@
 </div>
 
 <style>
-  .bottom-center {
+  .network-style {
     position: absolute;
     bottom: 10px;
-    width: 35vw;
-    left: 50%;
-    transform: translateX(-50%);
-
-    background: white;
-    padding: 4px;
+    width: 500px;
+    left: 0;
+    right: 0;
+    margin-inline: auto;
+    background-color: white;
+    padding: 10px;
+    font-size: 14px;
+  }
+  .network-style p,
+  .network-style :global(ul) {
+    margin: 0;
+  }
+  .network-style :global(ul) {
+    display: flex;
+    flex-direction: row;
+    margin: 0;
+  }
+  .network-style :global(ul li) {
+    flex-grow: 1;
+    flex-basis: 0;
+    list-style: none;
+  }
+  .network-style :global(ul li:last-child) {
+    margin-bottom: auto;
+  }
+  .network-style ul li button {
+    width: 100%;
+    border-radius: 0;
+    border: 1px solid gray;
+    background-color: #eee;
+    text-align: left;
+  }
+  .network-style ul li.selected button {
+    font-weight: bold;
+    background-color: #ccc;
+  }
+  .network-style :global(ul li label) {
+    display: block;
+    border-radius: 0;
+    padding: 2px 6px;
+    text-align: left;
+  }
+  .network-style :global(ul li:hover) {
+    color: black;
+    opacity: 0.9;
   }
 </style>

--- a/web/src/layers/roads/PopulationToggle.svelte
+++ b/web/src/layers/roads/PopulationToggle.svelte
@@ -3,6 +3,7 @@
 
   export let name: string;
   export let style: "off" | "population" | "deprived";
+  export let icon: string;
 
   function toggle() {
     if ($populationStyle == style) {
@@ -13,10 +14,9 @@
   }
 </script>
 
-<button
-  style:background={$populationStyle == style ? "green" : "grey"}
-  style:font-size="15px"
-  on:click={toggle}
->
-  {name}
-</button>
+<li>
+  <button class:selected={$populationStyle == style} on:click={toggle}>
+    <i class="fa-solid {icon}"></i>
+    {name}
+  </button>
+</li>

--- a/web/src/layers/roads/RightLayers.svelte
+++ b/web/src/layers/roads/RightLayers.svelte
@@ -25,35 +25,112 @@
 
 <div class="panel">
   <h3>Background layers</h3>
-  <Toggle name="Core network" style="cn" />
-  <Toggle name="Existing infrastructure type" style="existing_infra" />
-  <Toggle name="Estimated traffic volume" style="traffic" />
-  <Toggle name="Gradient" style="gradient" />
-  <Toggle name="Street space" style="street_space" />
-  <Toggle name="Estimated speed limit" style="speed" />
-  <Toggle name="NPT full network" style="precalculated_rnet" />
+  <ul>
+    <Toggle name="Core network" style="cn" icon="fa-person-biking" />
+    <Toggle
+      name="Existing infrastructure type"
+      style="existing_infra"
+      icon="fa-road"
+    />
+    <Toggle name="Estimated traffic volume" style="traffic" icon="fa-car" />
+    <Toggle name="Gradient" style="gradient" icon="fa-mound" />
+    <Toggle
+      name="Street space"
+      style="street_space"
+      icon="fa-ruler-horizontal"
+    />
+    <Toggle
+      name="Estimated speed limit"
+      style="speed"
+      icon="fa-gauge-simple-high"
+    />
+    <Toggle
+      name="NPT full network"
+      style="precalculated_rnet"
+      icon="fa-diagram-project"
+    />
+  </ul>
 
-  <h3>Evaluation</h3>
-  <Toggle name="Level of Service" style="los" />
-  <Toggle name="Reachability" style="reachability" />
-  <Toggle name="Route network (calculated)" style="calculated_rnet" />
-  <Toggle name="Network disconnections" style="disconnections" />
-  <Toggle name="Streetspace deliverability" style="deliverability" />
-
-  <hr />
-  <PopulationToggle name="Population" style="population" />
-  <PopulationToggle name="Deprived population (SIMD)" style="deprived" />
+  <h3>Evaluation layers</h3>
+  <ul>
+    <Toggle name="Level of Service" style="los" icon="fa-face-smile" />
+    <Toggle name="Reachability" style="reachability" icon="fa-link" />
+    <Toggle
+      name="Route network (calculated)"
+      style="calculated_rnet"
+      icon="fa-globe"
+    />
+    <Toggle
+      name="Network disconnections"
+      style="disconnections"
+      icon="fa-link-slash"
+    />
+    <Toggle
+      name="Streetspace deliverability"
+      style="deliverability"
+      icon="fa-person-digging"
+    />
+    <hr />
+    <PopulationToggle name="Population" style="population" icon="fa-person" />
+    <PopulationToggle
+      name="Deprived population (SIMD)"
+      style="deprived"
+      icon="fa-house-user"
+    />
+  </ul>
 </div>
 
 <style>
   .panel {
     position: absolute;
+    width: 165px;
     top: 10px;
     right: 10px;
-    width: 15%;
-
-    display: flex;
-    flex-direction: column;
-    background: white;
+    background-color: white;
+    overflow-y: auto;
+    padding: 10px;
+  }
+  .panel h3 {
+    font-size: 14px;
+  }
+  .panel :global(ul) {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .panel :global(ul li) {
+    margin: 0 0 6px;
+    padding: 0;
+    line-height: 14px;
+  }
+  .panel :global(ul li button) {
+    width: 100%;
+    border: 0;
+    border-left: 5px solid #ddd;
+    background-color: #f7f7f7;
+    text-align: left;
+    padding: 4px 8px;
+  }
+  .panel :global(button) {
+    background-color: #ccc;
+    font-size: 12px;
+    height: 36px;
+  }
+  .panel :global(button.selected),
+  .panel :global(button.selected i) {
+    color: #603;
+    border-color: #603;
+    background-color: #dcdcdc;
+  }
+  .panel :global(button.relevant) {
+    border-left-color: #666;
+  }
+  .panel :global(button i) {
+    display: block;
+    font-size: 16px;
+    width: 20px;
+    color: #aaa;
+    float: right;
+    line-height: 26px;
   }
 </style>

--- a/web/src/layers/roads/Toggle.svelte
+++ b/web/src/layers/roads/Toggle.svelte
@@ -5,6 +5,7 @@
   export let name: string;
   // TODO Use name for this
   export let style: ReferenceRoadStyle;
+  export let icon: string;
 
   function toggle() {
     if ($referenceRoadStyle == style) {
@@ -16,14 +17,13 @@
   }
 </script>
 
-<button
-  style:background={$referenceRoadStyle == style ? "green" : "grey"}
-  style:font-size="15px"
-  on:click={toggle}
->
-  {#if $referenceRoadStyle == "off" && $lastReferenceStyle == style}
-    <b>{name}</b>
-  {:else}
-    {name}
-  {/if}
-</button>
+<li>
+  <button class:selected={$referenceRoadStyle == style} on:click={toggle}>
+    <i class="fa-solid {icon}"></i>
+    {#if $referenceRoadStyle == "off" && $lastReferenceStyle == style}
+      <b>{name}</b>
+    {:else}
+      {name}
+    {/if}
+  </button>
+</li>

--- a/web/src/stats/LeftSidebarStats.svelte
+++ b/web/src/stats/LeftSidebarStats.svelte
@@ -36,87 +36,116 @@
 <Loading {loading} />
 
 {#if $stats}
-  <h4>Assess this tier</h4>
+  <div class="assess">
+    <h3>Assess this tier</h3>
 
-  {#if $currentStage == "Primary"}
-    <Metric
-      label="High cycling demand coverage"
-      pct={percent(
-        $stats.covered_demand_quintile_sums[0],
-        $stats.total_demand_quintile_sums[0],
-      )}
-    />
+    {#if $currentStage == "Primary"}
+      <Metric
+        label="High cycling demand coverage"
+        pct={percent(
+          $stats.covered_demand_quintile_sums[0],
+          $stats.total_demand_quintile_sums[0],
+        )}
+      />
 
-    <Metric
-      label="Main road coverage"
-      pct={percent(
-        $stats.covered_main_road_length,
-        $stats.total_main_road_length,
-      )}
-    />
-  {:else if $currentStage == "Secondary"}
-    <Metric
-      label="Medium cycling demand coverage"
-      pct={percent(
-        $stats.covered_demand_quintile_sums[1],
-        $stats.total_demand_quintile_sums[1],
-      )}
-    />
+      <Metric
+        label="Main road coverage"
+        pct={percent(
+          $stats.covered_main_road_length,
+          $stats.total_main_road_length,
+        )}
+      />
+    {:else if $currentStage == "Secondary"}
+      <Metric
+        label="Medium cycling demand coverage"
+        pct={percent(
+          $stats.covered_demand_quintile_sums[1],
+          $stats.total_demand_quintile_sums[1],
+        )}
+      />
 
-    <Metric label="Town centres" pct={$stats.percent_reachable_town_centres} />
-  {:else if $currentStage == "LocalAccess"}
-    <Metric label="Schools" pct={$stats.percent_reachable_schools} />
+      <Metric
+        label="Town centres"
+        pct={$stats.percent_reachable_town_centres}
+      />
+    {:else if $currentStage == "LocalAccess"}
+      <Metric label="Schools" pct={$stats.percent_reachable_schools} />
 
-    <Metric
-      label="GPs and hospitals"
-      pct={$stats.percent_reachable_gp_hospitals}
-    />
+      <Metric
+        label="GPs and hospitals"
+        pct={$stats.percent_reachable_gp_hospitals}
+      />
 
-    <Metric label="Greenspaces" pct={$stats.percent_reachable_greenspaces} />
+      <Metric label="Greenspaces" pct={$stats.percent_reachable_greenspaces} />
 
-    <Metric
-      label="Deprived population coverage"
-      pct={$stats.percent_reachable_imd_population}
-    />
+      <Metric
+        label="Deprived population coverage"
+        pct={$stats.percent_reachable_imd_population}
+      />
 
-    <Metric
-      label="Population coverage"
-      pct={$stats.percent_reachable_population}
-    />
-  {:else if $currentStage == "LongDistance"}
-    <Metric label="Settlements" pct={$stats.percent_reachable_settlements} />
-  {:else if $currentStage == "assessment"}
-    <FinalReport />
+      <Metric
+        label="Population coverage"
+        pct={$stats.percent_reachable_population}
+      />
+    {:else if $currentStage == "LongDistance"}
+      <Metric label="Settlements" pct={$stats.percent_reachable_settlements} />
+    {:else if $currentStage == "assessment"}
+      <FinalReport />
 
-    <button on:click={recalcOD} disabled={$mutationCounter == lastUpdateOD}>
-      Recalculate
-    </button>
+      <button on:click={recalcOD} disabled={$mutationCounter == lastUpdateOD}>
+        Recalculate
+      </button>
 
-    {#if $odStats}
-      <div style:margin-top="4px" style:border="2px solid black">
+      {#if $odStats}
+        <div style:margin-top="4px" style:border="2px solid black">
+          <p>
+            <!-- svelte-ignore a11y-invalid-attribute -->
+            <a
+              href="#"
+              on:click|preventDefault={() =>
+                ($mode = {
+                  kind: "evaluate-journey",
+                  prevMode: { kind: "main" },
+                  browse: notNull($odStats).worst_directness_routes,
+                })}
+            >
+              Average weighted directness
+            </a>
+            : {$odStats.average_weighted_directness.toFixed(1)}x
+          </p>
+
+          <ODBreakdowns od={$odStats} />
+        </div>
+      {:else}
         <p>
-          <!-- svelte-ignore a11y-invalid-attribute -->
-          <a
-            href="#"
-            on:click|preventDefault={() =>
-              ($mode = {
-                kind: "evaluate-journey",
-                prevMode: { kind: "main" },
-                browse: notNull($odStats).worst_directness_routes,
-              })}
-          >
-            Average weighted directness
-          </a>
-          : {$odStats.average_weighted_directness.toFixed(1)}x
+          Initial stats calculation disabled for faster start. Press the button
+          above.
         </p>
-
-        <ODBreakdowns od={$odStats} />
-      </div>
-    {:else}
-      <p>
-        Initial stats calculation disabled for faster start. Press the button
-        above.
-      </p>
+      {/if}
     {/if}
-  {/if}
+  </div>
 {/if}
+
+<style>
+  .assess {
+    margin-top: auto;
+    height: auto;
+    width: 100%;
+    padding: 0 20px;
+    border-top: 1px solid #ccc;
+    padding: 12px 20px 8px;
+  }
+
+  .assess :global(strong) {
+    float: right;
+  }
+
+  .assess :global(progress) {
+    width: 100%;
+    --color: var(--primary-tier-colour);
+  }
+  .assess :global(p) {
+    margin-bottom: 12px;
+    line-height: 20px;
+  }
+</style>

--- a/web/src/stats/Metric.svelte
+++ b/web/src/stats/Metric.svelte
@@ -4,10 +4,9 @@
   export let tooltip: string | undefined = undefined;
 </script>
 
-<div style="display: flex; flex-direction: column" title={tooltip}>
-  <span>
-    {label}:
-    <b>{Math.round(pct * 100)}%</b>
-  </span>
-  <progress value={pct * 100} max="100" />
-</div>
+<p title={tooltip}>
+  {label}:
+  <strong>{Math.round(pct * 100)}%</strong>
+  <br />
+  <progress value={pct * 100} max="100"></progress>
+</p>

--- a/web/src/stats/TopBarStats.svelte
+++ b/web/src/stats/TopBarStats.svelte
@@ -1,51 +1,89 @@
 <script lang="ts">
   import { stats } from "../stores";
-  import TerseMetric from "./TerseMetric.svelte";
 
   // Returns something [0, 1]
   function percent(x: number, total: number): number {
     if (total == 0) {
       return 0;
     }
-    return x / total;
+    return (100 * x) / total;
   }
 </script>
 
 {#if $stats}
-  <div class="progress" style:display="flex" style:gap="3em">
-    <TerseMetric
-      label="Safety"
-      pct={percent($stats.total_high_los_length, $stats.total_network_length)}
-      tooltip="What percent of your network has high Level of Service?"
-    />
+  <div class="progress-summary">
+    <ul>
+      <li title="What percent of your network has high Level of Service?">
+        Safety
+        <br />
+        <progress
+          value={percent(
+            $stats.total_high_los_length,
+            $stats.total_network_length,
+          )}
+          max="100"
+        />
+      </li>
 
-    <TerseMetric
-      label="Comfort"
-      pct={percent(
-        $stats.total_low_gradient_length,
-        $stats.total_network_length,
-      )}
-      tooltip="What percent of your network is on low gradient (&le; 3%)?"
-    />
+      <li title="What percent of your network is on low gradient (&le; 3%)?">
+        Comfort
+        <br />
+        <progress
+          value={percent(
+            $stats.total_low_gradient_length,
+            $stats.total_network_length,
+          )}
+          max="100"
+        />
+      </li>
 
-    <TerseMetric
-      label="Coherence (main roads)"
-      pct={percent(
-        $stats.covered_main_road_length,
-        $stats.total_main_road_length,
-      )}
-    />
+      <li>
+        Coherence (main roads)
+        <br />
+        <progress
+          value={percent(
+            $stats.covered_main_road_length,
+            $stats.total_main_road_length,
+          )}
+          max="100"
+        />
+      </li>
 
-    <div
-      style="display: flex; flex-direction: column"
-      title="Density of primary/secondary network within settlements"
-    >
-      <span>Coherence (density)</span>
-      {#if $stats.density_network_in_settlements}
-        <b>{Math.round($stats.density_network_in_settlements)}m</b>
-      {:else}
-        <b>no routes yet</b>
-      {/if}
-    </div>
+      <li title="Density of primary/secondary network within settlements">
+        Coherence (density)
+        <br />
+        {#if $stats.density_network_in_settlements}
+          {Math.round($stats.density_network_in_settlements)}m
+        {:else}
+          no routes yet
+        {/if}
+      </li>
+    </ul>
   </div>
 {/if}
+
+<style>
+  /* TODO Does this do anything? Why the big <a>?
+  .progress-summary a {
+    text-decoration: none;
+    color: #1a1a1a;
+    }*/
+  .progress-summary ul {
+    height: 100%;
+    list-style: none;
+    display: flex;
+    margin: 0;
+    padding: 0;
+  }
+  .progress-summary ul li {
+    list-style: none;
+    font-size: 1rem;
+    margin: 0;
+    width: 100px;
+    line-height: 12px;
+    padding: 12px 6px 4px;
+  }
+  .progress-summary ul li progress {
+    width: 100%;
+  }
+</style>

--- a/web/src/stats/TopBarStats.svelte
+++ b/web/src/stats/TopBarStats.svelte
@@ -25,6 +25,34 @@
         />
       </li>
 
+      <li title="TODO: Placeholder score">
+        Directness
+        <br />
+        <progress value="50" max="100" />
+      </li>
+
+      <li title="Percent of main roads covered by network">
+        Coherence
+        <br />
+        <progress
+          value={percent(
+            $stats.covered_main_road_length,
+            $stats.total_main_road_length,
+          )}
+          max="100"
+        />
+      </li>
+
+      <!--<li title="Density of primary/secondary network within settlements">
+        Coherence (density)
+        <br />
+        {#if $stats.density_network_in_settlements}
+          {Math.round($stats.density_network_in_settlements)}m
+        {:else}
+          no routes yet
+        {/if}
+      </li>-->
+
       <li title="What percent of your network is on low gradient (&le; 3%)?">
         Comfort
         <br />
@@ -37,26 +65,10 @@
         />
       </li>
 
-      <li>
-        Coherence (main roads)
+      <li title="TODO: Placeholder score">
+        Attractiveness
         <br />
-        <progress
-          value={percent(
-            $stats.covered_main_road_length,
-            $stats.total_main_road_length,
-          )}
-          max="100"
-        />
-      </li>
-
-      <li title="Density of primary/secondary network within settlements">
-        Coherence (density)
-        <br />
-        {#if $stats.density_network_in_settlements}
-          {Math.round($stats.density_network_in_settlements)}m
-        {:else}
-          no routes yet
-        {/if}
+        <progress value="50" max="100" />
       </li>
     </ul>
   </div>

--- a/web/src/stats/TopBarStats.svelte
+++ b/web/src/stats/TopBarStats.svelte
@@ -75,6 +75,11 @@
 {/if}
 
 <style>
+  .progress-summary {
+    padding-left: 20px;
+    margin-left: auto;
+  }
+
   /* TODO Does this do anything? Why the big <a>?
   .progress-summary a {
     text-decoration: none;

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -124,57 +124,8 @@ body main[slot="assess"] progress[value] {
 img.help {
   float: right;
 }
-main.map-container .network-style {
-  position: absolute;
-  bottom: 10px;
-  width: 500px;
-  left: 0;
-  right: 0;
-  margin-inline: auto;
-  background-color: white;
-  padding: 10px;
-  font-size: 14px;
-}
 main.map-container .network-style img.help {
   height: 16px;
-}
-main.map-container .network-style p,
-main.map-container .network-style ul {
-  margin: 0;
-}
-main.map-container .network-style ul {
-  display: flex;
-  flex-direction: row;
-  margin: 0;
-}
-main.map-container .network-style ul li {
-  flex-grow: 1;
-  flex-basis: 0;
-  list-style: none;
-}
-main.map-container .network-style ul li:last-child {
-  margin-bottom: auto;
-}
-main.map-container .network-style ul li button {
-  width: 100%;
-  border-radius: 0;
-  border: 1px solid gray;
-  background-color: #eee;
-  text-align: left;
-}
-main.map-container .network-style ul li.selected button {
-  font-weight: bold;
-  background-color: #ccc;
-}
-main.map-container .network-style ul li label {
-  display: block;
-  border-radius: 0;
-  padding: 2px 6px;
-  text-align: left;
-}
-main.map-container .network-style ul li:hover {
-  color: black;
-  opacity: 0.9;
 }
 
 /* Overrides to styles */

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -176,60 +176,6 @@ main.map-container .network-style ul li:hover {
   color: black;
   opacity: 0.9;
 }
-main.map-container .panel {
-  position: absolute;
-  width: 165px;
-  top: 10px;
-  right: 10px;
-  background-color: white;
-  overflow-y: auto;
-  padding: 10px;
-}
-main.map-container .panel h3 {
-  font-size: 14px;
-}
-main.map-container .panel ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-main.map-container .panel ul li {
-  margin: 0 0 6px;
-  padding: 0;
-  line-height: 14px;
-}
-main.map-container .panel ul li button {
-  width: 100%;
-  background-color: white;
-  border: 0;
-  border-left: 5px solid #ddd;
-  background-color: #f7f7f7;
-  text-align: left;
-  padding: 4px 8px;
-}
-main.map-container .panel button {
-  background-color: #ccc;
-  font-size: 12px;
-  height: 36px;
-}
-main.map-container .panel button.selected,
-main.map-container .panel button.selected i {
-  color: #603;
-  border-color: #603;
-  background-color: #dcdcdc;
-}
-main.map-container .panel button.relevant {
-  border-left-color: #666;
-}
-main.map-container .panel button i {
-  display: block;
-  font-size: 16px;
-  width: 20px;
-  color: #aaa;
-  float: right;
-  line-height: 26px;
-  vertical-align: middle;
-}
 
 /* Overrides to styles */
 body .ds_page-header {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -38,22 +38,6 @@ main.map-container {
 }
 
 /* Layout - new */
-.top header {
-  display: flex;
-  padding: 0 20px;
-  box-shadow: 0px 10px 10px 0px #eee;
-}
-.top header #logo {
-  height: 30px;
-  margin-right: 10px;
-  vertical-align: middle;
-}
-.top header .site-navigation {
-}
-.top header .progress-summary {
-  padding-left: 20px;
-  margin-left: auto;
-}
 .progress-summary a {
   text-decoration: none;
   color: #1a1a1a;
@@ -135,13 +119,6 @@ body .ds_page-header {
 body .ds_page-header .ds_page-header__label {
   color: var(--primary-tier-colour);
 }
-body .ds_site-navigation .ds_site-navigation__link {
-  padding-left: 8px;
-  padding-right: 8px;
-}
-body .ds_site-navigation .ds_current {
-  font-weight: bold;
-}
 body .ds_link {
   font-size: 0.93rem;
   margin-bottom: 14px;
@@ -150,30 +127,14 @@ body main[slot="assess"] p {
   margin-bottom: 12px;
   line-height: 20px;
 }
+header .progress-summary {
+  padding-left: 20px;
+  margin-left: auto;
+}
 
 :root {
   --primary-tier-colour: #970f52;
   --secondary-tier-colour: #ff978c;
   --localaccess-tier-colour: #feae01;
   --longdistance-tier-colour: #fef157;
-}
-body
-  .ds_site-navigation
-  .ds_site-navigation__link.primary-tier:not(:focus):after {
-  border-bottom-color: var(--primary-tier-colour);
-}
-body
-  .ds_site-navigation
-  .ds_site-navigation__link.secondary-tier:not(:focus):after {
-  border-bottom-color: var(--secondary-tier-colour);
-}
-body
-  .ds_site-navigation
-  .ds_site-navigation__link.localaccess-tier:not(:focus):after {
-  border-bottom-color: var(--localaccess-tier-colour);
-}
-body
-  .ds_site-navigation
-  .ds_site-navigation__link.longdistance-tier:not(:focus):after {
-  border-bottom-color: var(--primary-tier-colour);
 }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -38,28 +38,6 @@ main.map-container {
 }
 
 /* Layout - new */
-.progress-summary a {
-  text-decoration: none;
-  color: #1a1a1a;
-}
-.progress-summary ul {
-  height: 100%;
-  list-style: none;
-  display: flex;
-  margin: 0;
-  padding: 0;
-}
-.progress-summary ul li {
-  list-style: none;
-  font-size: 1rem;
-  margin: 0;
-  width: 100px;
-  line-height: 12px;
-  padding: 12px 6px 4px;
-}
-.progress-summary ul li progress {
-  width: 100%;
-}
 .controls {
   display: flex;
   flex-direction: column;

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2,65 +2,12 @@
 body {
   margin: 0;
 }
-#app {
-}
-.flex-container {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-  margin: 0;
-}
-.top {
-  /* padding: 4px; */
-}
-.content {
-  display: flex;
-  flex: 1;
-  overflow: hidden;
-}
 
 /* Layout - existing */
 header {
   width: 100%; /* padding: 4px; */
 }
-.controls {
-  width: 25%; /* padding: 10px; */
-  min-width: 350px;
-}
-.map {
-  width: 75%;
-}
-main.map-container {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  background-color: #e7e7e7;
-}
 
-/* Layout - new */
-.controls {
-  display: flex;
-  flex-direction: column;
-  justify-content: space between;
-}
-.controls main[slot="controls"] {
-  overflow-y: auto;
-  padding: 20px;
-}
-.controls main[slot="assess"] {
-  margin-top: auto;
-  height: auto;
-  width: 100%;
-  padding: 0 20px;
-  border-top: 1px solid #ccc;
-  padding: 12px 20px 8px;
-}
-.controls main[slot="assess"] strong {
-  float: right;
-}
-.controls main[slot="assess"] progress {
-  width: 100%;
-}
 /* https://verpex.com/blog/website-tips/how-to-style-a-progress-bar-using-css */
 progress[value] {
   appearance: none;
@@ -80,9 +27,6 @@ progress[value]::-webkit-progress-value {
 progress[value]::-moz-progress-bar {
   background: var(--color);
 }
-body main[slot="assess"] progress[value] {
-  --color: var(--primary-tier-colour);
-}
 
 /* Overrides to styles */
 body .ds_page-header {
@@ -94,10 +38,6 @@ body .ds_page-header .ds_page-header__label {
 body .ds_link {
   font-size: 0.93rem;
   margin-bottom: 14px;
-}
-body main[slot="assess"] p {
-  margin-bottom: 12px;
-  line-height: 20px;
 }
 
 :root {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1,8 +1,282 @@
-button {
-  border-radius: 10%;
-  padding: 4px;
+/* Svelte framework built-ins */
+body {
+  margin: 0;
+}
+#app {
+}
+.flex-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  margin: 0;
+}
+.top {
+  /* padding: 4px; */
+}
+.content {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
 }
 
-.primary {
-  background: green;
+/* Layout - existing */
+header {
+  width: 100%; /* padding: 4px; */
+}
+.controls {
+  width: 25%; /* padding: 10px; */
+  min-width: 350px;
+}
+.map {
+  width: 75%;
+}
+main.map-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background-color: #e7e7e7;
+}
+
+/* Layout - new */
+.top header {
+  display: flex;
+  padding: 0 20px;
+  box-shadow: 0px 10px 10px 0px #eee;
+}
+.top header #logo {
+  height: 30px;
+  margin-right: 10px;
+  vertical-align: middle;
+}
+.top header .site-navigation {
+}
+.top header .progress-summary {
+  padding-left: 20px;
+  margin-left: auto;
+}
+.progress-summary a {
+  text-decoration: none;
+  color: #1a1a1a;
+}
+.progress-summary ul {
+  height: 100%;
+  list-style: none;
+  display: flex;
+  margin: 0;
+  padding: 0;
+}
+.progress-summary ul li {
+  list-style: none;
+  font-size: 1rem;
+  margin: 0;
+  width: 100px;
+  line-height: 12px;
+  padding: 12px 6px 4px;
+}
+.progress-summary ul li progress {
+  width: 100%;
+}
+.controls {
+  display: flex;
+  flex-direction: column;
+  justify-content: space between;
+}
+.controls main[slot="controls"] {
+  overflow-y: auto;
+  padding: 20px;
+}
+.controls main[slot="assess"] {
+  margin-top: auto;
+  height: auto;
+  width: 100%;
+  padding: 0 20px;
+  border-top: 1px solid #ccc;
+  padding: 12px 20px 8px;
+}
+.controls main[slot="assess"] strong {
+  float: right;
+}
+.controls main[slot="assess"] progress {
+  width: 100%;
+}
+/* https://verpex.com/blog/website-tips/how-to-style-a-progress-bar-using-css */
+progress[value] {
+  appearance: none;
+  --color: #0065bd;
+  --background: lightgrey;
+  width: 100%;
+  height: 5px;
+  margin: 0;
+  background: var(--background);
+}
+progress[value]::-webkit-progress-bar {
+  background: var(--background);
+}
+progress[value]::-webkit-progress-value {
+  background: var(--color);
+}
+progress[value]::-moz-progress-bar {
+  background: var(--color);
+}
+body main[slot="assess"] progress[value] {
+  --color: var(--primary-tier-colour);
+}
+img.help {
+  float: right;
+}
+main.map-container .network-style {
+  position: absolute;
+  bottom: 10px;
+  width: 500px;
+  left: 0;
+  right: 0;
+  margin-inline: auto;
+  background-color: white;
+  padding: 10px;
+  font-size: 14px;
+}
+main.map-container .network-style img.help {
+  height: 16px;
+}
+main.map-container .network-style p,
+main.map-container .network-style ul {
+  margin: 0;
+}
+main.map-container .network-style ul {
+  display: flex;
+  flex-direction: row;
+  margin: 0;
+}
+main.map-container .network-style ul li {
+  flex-grow: 1;
+  flex-basis: 0;
+  list-style: none;
+}
+main.map-container .network-style ul li:last-child {
+  margin-bottom: auto;
+}
+main.map-container .network-style ul li button {
+  width: 100%;
+  border-radius: 0;
+  border: 1px solid gray;
+  background-color: #eee;
+  text-align: left;
+}
+main.map-container .network-style ul li.selected button {
+  font-weight: bold;
+  background-color: #ccc;
+}
+main.map-container .network-style ul li label {
+  display: block;
+  border-radius: 0;
+  padding: 2px 6px;
+  text-align: left;
+}
+main.map-container .network-style ul li:hover {
+  color: black;
+  opacity: 0.9;
+}
+main.map-container .panel {
+  position: absolute;
+  width: 165px;
+  top: 10px;
+  right: 10px;
+  background-color: white;
+  overflow-y: auto;
+  padding: 10px;
+}
+main.map-container .panel h3 {
+  font-size: 14px;
+}
+main.map-container .panel ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+main.map-container .panel ul li {
+  margin: 0 0 6px;
+  padding: 0;
+  line-height: 14px;
+}
+main.map-container .panel ul li button {
+  width: 100%;
+  background-color: white;
+  border: 0;
+  border-left: 5px solid #ddd;
+  background-color: #f7f7f7;
+  text-align: left;
+  padding: 4px 8px;
+}
+main.map-container .panel button {
+  background-color: #ccc;
+  font-size: 12px;
+  height: 36px;
+}
+main.map-container .panel button.selected,
+main.map-container .panel button.selected i {
+  color: #603;
+  border-color: #603;
+  background-color: #dcdcdc;
+}
+main.map-container .panel button.relevant {
+  border-left-color: #666;
+}
+main.map-container .panel button i {
+  display: block;
+  font-size: 16px;
+  width: 20px;
+  color: #aaa;
+  float: right;
+  line-height: 26px;
+  vertical-align: middle;
+}
+
+/* Overrides to styles */
+body .ds_page-header {
+  margin: 0 0 14px;
+}
+body .ds_page-header .ds_page-header__label {
+  color: var(--primary-tier-colour);
+}
+body .ds_site-navigation .ds_site-navigation__link {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+body .ds_site-navigation .ds_current {
+  font-weight: bold;
+}
+body .ds_link {
+  font-size: 0.93rem;
+  margin-bottom: 14px;
+}
+body main[slot="assess"] p {
+  margin-bottom: 12px;
+  line-height: 20px;
+}
+
+:root {
+  --primary-tier-colour: #970f52;
+  --secondary-tier-colour: #ff978c;
+  --localaccess-tier-colour: #feae01;
+  --longdistance-tier-colour: #fef157;
+}
+body
+  .ds_site-navigation
+  .ds_site-navigation__link.primary-tier:not(:focus):after {
+  border-bottom-color: var(--primary-tier-colour);
+}
+body
+  .ds_site-navigation
+  .ds_site-navigation__link.secondary-tier:not(:focus):after {
+  border-bottom-color: var(--secondary-tier-colour);
+}
+body
+  .ds_site-navigation
+  .ds_site-navigation__link.localaccess-tier:not(:focus):after {
+  border-bottom-color: var(--localaccess-tier-colour);
+}
+body
+  .ds_site-navigation
+  .ds_site-navigation__link.longdistance-tier:not(:focus):after {
+  border-bottom-color: var(--primary-tier-colour);
 }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -83,12 +83,6 @@ progress[value]::-moz-progress-bar {
 body main[slot="assess"] progress[value] {
   --color: var(--primary-tier-colour);
 }
-img.help {
-  float: right;
-}
-main.map-container .network-style img.help {
-  height: 16px;
-}
 
 /* Overrides to styles */
 body .ds_page-header {
@@ -104,10 +98,6 @@ body .ds_link {
 body main[slot="assess"] p {
   margin-bottom: 12px;
   line-height: 20px;
-}
-header .progress-summary {
-  padding-left: 20px;
-  margin-left: auto;
 }
 
 :root {


### PR DESCRIPTION
#60 
Apply much of @mvl22's design work to the main page too. Cici and I need to iterate a bit on the ordering / contents of the draw page, and it's easier to do with the new designs started. This PR is imperfect, but it's a strict improvement over the current plain HTML styling for demo purposes. Will keep iterating quickly on this. Martin, please continue to work on your stubbed-out pages assuming that's easier; I'll apply any changes you make there accordingly.

An incomplete list of things to fix up later:

- [ ] Get rid of the old Link component probably
- [ ] Right layers: decide what to do about the last selected hotkey
- [ ] Show relevant layers on the right, and maybe get rid of them on the left now?
- [ ] In the top bar, the link highlighting includes the `>`
- [ ] Decide where the help button for tiers should go
- [ ] For the left bar assess metrics, change the progress bar based on the tier
- [ ] Bulk edit mode needs fixing
- [ ] Evaluate journey mode needs fixing
- [ ] Final report needs fixing
- [ ] The padding / scrolling in draw mode is very wrong