### PR TITLE
WIP get sticky bottom div to work

### DIFF
--- a/web/src/MainMode.svelte
+++ b/web/src/MainMode.svelte
@@ -126,15 +126,44 @@
       {#if $currentStage != "LocalAccess"}
         <RelevantLayers />
       {/if}
+
+      <p>More content...</p>
+      <p>More content...</p>
+      <p>More content...</p>
+      <p>More content...</p>
+      <p>More content...</p>
+      <p>More content...</p>
+      <p>More content...</p>
     </div>
 
-    <LeftSidebarStats />
+    <div class="assess-sticky-bottom">
+      <LeftSidebarStats />
+    </div>
   </div>
 </SplitComponent>
 
 <style>
+  div[slot="controls"] {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    /*background: red;*/
+
+    /* TODO I can't get this to be 100% of the height beneath the top bar */
+    height: 600px;
+  }
+
   .main-controls {
     overflow-y: auto;
     padding: 20px;
+  }
+
+  .assess-sticky-bottom {
+    margin-top: auto;
+    height: auto;
+    width: 100%;
+    padding: 0 20px;
+    border-top: 1px solid #ccc;
+    padding: 12px 20px 8px;
   }
 </style>

--- a/web/src/common/layout/Layout.svelte
+++ b/web/src/common/layout/Layout.svelte
@@ -27,15 +27,8 @@
   }
 
   .controls {
-    width: 25%; /* padding: 10px; */
+    width: 25%;
     min-width: 350px;
-
-    /* TODO no effect? */
-    display: flex;
-    flex-direction: column;
-    justify-content: space between;
-    /* TODO hack, only want some parts to scroll */
-    overflow: auto;
   }
 
   .map {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f4dcce65-a955-496f-ac81-1775f9f79c65)
I'm closer, but I can't get the `div[slot="controls"]` to take all of the screen height - the top bar. There are some intermediate `div`s in `common/layout`, and I think the chain of flex-grow is getting lost somewhere.